### PR TITLE
split address

### DIFF
--- a/www/js/services/groups.js
+++ b/www/js/services/groups.js
@@ -181,7 +181,11 @@ angular.module('app.services').factory('groups',function ($resource, serverConfi
       permissions_name: 'Name',
       permissions_contacts: 'Contact information',
       permissions_responses: 'Responses',
-      permissions_address: 'Address',
+      permissions_address: 'Street Address',
+      permissions_city: 'City',
+      permissions_state: 'State',
+      permissions_country: 'Country',
+      permissions_zip_code: 'Zip Code',
       permissions_email: 'Email',
       permissions_phone: 'Phone Number'
     },


### PR DESCRIPTION
 when user join to group and the group require address a permission. 

This change caused by the changes on [poweline-server](https://github.com/PowerlineApp/powerline-server/pull/44).
